### PR TITLE
add POST method to form

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -10,7 +10,7 @@ title: Contact Long Haul
     <p>The form is provided by <a href="http://formspree.io/">Formspree.</a> Follow the directions on their site to set up the form for use.</p>
     <p>If you have questions about the theme feel free to <a href="mailto:brimaidesigns@gmail.com">email me</a> or create an issue on <a href="https://github.com/brianmaierjr/long-haul">GitHub</a>. Enjoy!</p>
   </div>
-  <form action="http://formspree.io/your@mail.com">
+  <form action="http://formspree.io/your@mail.com" method="POST">
     <label for="name">Name</label>    
     <input type="text" id="name" name="name" class="full-width"><br>
     <label for="email">Email Address</label>


### PR DESCRIPTION
Formspree requires that the form action includes ```method = "POST"```.

Without this an error is raised.

See http://formspree.io/

PR address this.