### PR TITLE
Fixing current highlighting for permalink: pretty

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
          <h1 class="logo"><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
          <nav class="nav-collapse">
              <ul class="noList">
-                 {% for link in site.navigation %}{% assign current = nil %}{% if page.url contains link.url %}{% assign current = 'current' %}{% endif %}
+                 {% for link in site.navigation %}{% assign current = nil %}{% if page.url == link.url %}{% assign current = 'current' %}{% endif %}
                  <li class="element {% if forloop.first %}first{% endif %} {{ current }} {% if forloop.last %}last{% endif %}">
                      <a href="{{ link.url | prepend: site.baseurl }}">{{ link.title }}</a>
                  </li> 


### PR DESCRIPTION
If you modify YAML front matter such that:
"/index.html"  -> "/"; then "/" is contained in "/about/" etc. breaking the current highlighting.
