### PR TITLE
Fixing the email icon in footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,8 +25,8 @@
                   </svg>
             </a></li>
             {% endif %} 
-            {% if site.email %}
-            <li><a href="mailto:{{ site.email }}">
+            {% if site.social.email %}
+            <li><a href="mailto:{{ site.social.email }}">
                   <svg id="mail" class="custom-icon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" style="height: 30px; width: 30px;"><circle class="outer-shape" cx="50" cy="50" r="48" style="opacity: 1;"></circle>
                   <path class="inner-shape" style="opacity: 1;" transform="translate(25,25) scale(0.5)" d="M50,1C22.938,1,1,22.938,1,50s21.938,49,49,49s49-21.938,49-49S77.062,1,50,1z M25.5,25.5h49 c0.874,0,1.723,0.188,2.502,0.542L50,57.544L22.998,26.041C23.777,25.687,24.626,25.499,25.5,25.5L25.5,25.5z M19.375,68.375v-36.75 c0-0.128,0.005-0.256,0.014-0.383l17.96,20.953L19.587,69.958C19.448,69.447,19.376,68.916,19.375,68.375L19.375,68.375z M74.5,74.5 h-49c-0.541,0-1.072-0.073-1.583-0.212l17.429-17.429L50,66.956l8.653-10.096l17.429,17.429C75.572,74.427,75.041,74.5,74.5,74.5 L74.5,74.5z M80.625,68.375c0,0.541-0.073,1.072-0.211,1.583L62.652,52.195l17.96-20.953c0.008,0.127,0.014,0.255,0.014,0.383 L80.625,68.375L80.625,68.375z"></path>
                   </svg>


### PR DESCRIPTION
Hi,
I noticed that the email icon was not shown in footer. 
This commit should do the trick.
Just replaced {{ site.email }} with {{ site.social.email }}.
Thanks for the theme!