### PR TITLE
Require `support-for` in `config.rb`

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,4 +1,5 @@
 # Require any additional compass plugins here.
+require "support-for"
 require "normalize-scss"
 require "susy"
 


### PR DESCRIPTION
This should fix #29 .

**Full compilation output**:
```
$ compass compile
    write assets/css/ie.css
DEPRECATION WARNING on line 87 of /home/nobody/.gem/ruby/gems/compass-core-1.0.3/stylesheets/compass/css3/_deprecated-support.scss: #{} interpolation near operators will be simplified
in a future version of Sass. To preserve the current behavior, use quotes:

  unquote('"$moz-"#{$experimental-support-for-mozilla} "$webkit-"#{$experimental-support-for-webkit} "$opera-"#{$experimental-support-for-opera} "$microsoft-"#{$experimental-support-for-microsoft} "$khtml-"#{$experimental-support-for-khtml}')

You can use the sass-convert command to automatically fix most cases.

DEPRECATION WARNING on line 92 of /home/nobody/.gem/ruby/gems/compass-core-1.0.3/stylesheets/compass/css3/_deprecated-support.scss: #{} interpolation near operators will be simplified
in a future version of Sass. To preserve the current behavior, use quotes:

  unquote('"$ie6-"#{$legacy-support-for-ie6} "$ie7-"#{$legacy-support-for-ie7} "$ie8-"#{$legacy-support-for-ie8}')

You can use the sass-convert command to automatically fix most cases.

DEPRECATION WARNING on line 70 of /home/nobody/.gem/ruby/gems/susy-2.2.9/sass/susy/output/support/_support.scss: #{} interpolation near operators will be simplified
in a future version of Sass. To preserve the current behavior, use quotes:

  unquote("#{$_type}-exists")

    write assets/css/style.css

```