### PR TITLE
'pygments' highlighter is no longer supported

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ paginate_path: "blog/page:num/"
 permalink: blog/:title/
 
 markdown: redcarpet
-highlighter: pygments
+highlighter: rouge
 gems: [jekyll-paginate]
 paginate: 5
 


### PR DESCRIPTION
For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.