### PR TITLE
Github no longer supports redcarpet: now kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ baseurl: ""
 paginate_path: "blog/page:num/"
 permalink: blog/:title/
 
-markdown: redcarpet
+markdown: kramdown
 highlighter: rouge
 gems: [jekyll-paginate]
 paginate: 5

--- a/_posts/2014-12-15-example-post-formatting.markdown
+++ b/_posts/2014-12-15-example-post-formatting.markdown
@@ -7,10 +7,15 @@ date:   2014-12-15
 <p class="intro"><span class="dropcap">C</span>urabitur blandit tempus porttitor. Nullam quis risus eget urna mollis ornare vel eu leo. Vestibulum id ligula porta felis euismod semper. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur.</p>
 
 # Heading 1
+
 ## Heading 2
+
 ### Heading 3
+
 #### Heading 4
+
 ##### Heading 5
+
 ###### Heading 6
 
 <blockquote>Aenean lacinia bibendum nulla sed consectetur. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras mattis consectetur purus sit amet fermentum. Nulla vitae elit libero, a pharetra augue. Curabitur blandit tempus porttitor. Donec sed odio dui. Cras mattis consectetur purus sit amet fermentum.</blockquote>


### PR DESCRIPTION
"Starting May 1st, 2016, GitHub Pages will only support kramdown."
https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0