### PR TITLE
Add katex support

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,10 @@
     <!--[if IE 8]><link rel="stylesheet" href="{{ "/assets/css/ie.css" | prepend: site.baseurl }}"><![endif]-->
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
+    <!-- Katex support -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js" type="text/javascript"></script>
+
     <!-- Modernizr -->
     <script src="{{ "/assets/js/modernizr.custom.15390.js" | prepend: site.baseurl }}" type="text/javascript"></script>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,21 @@
       </div>
    </div><!-- end .content -->
 
+   <!-- Katex -->
+   <script>
+        var scripts = document.getElementsByTagName("script");
+        for (var i = 0; i < scripts.length; i++) {
+            var script = scripts[i];
+            if (script.type.match(/^math\/tex/)) {
+                var text = script.text === "" ? script.innerHTML : script.text;
+                var options = script.type.match(/mode\s*=\s*display/) ?
+                              {displayMode: true} : {};
+                script.insertAdjacentHTML("beforebegin",
+                                          katex.renderToString(text, options));
+            }
+        }
+    </script>
+
    {% include footer.html %}
    {% include scripts.html %}
 


### PR DESCRIPTION
Adding katex support for writing math equations in markdown.

Kramdown switches sytax like '$$ ... $$' to scripts.

Added code finds those scripts and transfer to katex codes in html.

Idea and implementation was brought from

https://github.com/altosaar/jaan.io