### PR TITLE
Load fonts over https

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,8 +6,8 @@
  * 2. Prevent adjustments of font size after orientation changes in
  *    IE on Windows Phone and in iOS.
  */
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300,400,800);
-@import url(http://fonts.googleapis.com/css?family=PT+Serif:400,700,400italic,700italic);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,800);
+@import url(https://fonts.googleapis.com/css?family=PT+Serif:400,700,400italic,700italic);
 html {
   line-height: 1.15;
   /* 1 */


### PR DESCRIPTION
Because GH Pages are often loaded over https, browsers like Chrome will show the user a mixed content warning when this CSS tries to load fonts over unsecure http.

![image](https://user-images.githubusercontent.com/1066253/33532274-15f91676-d84d-11e7-921b-a110bd7a8180.png)


This PR updates the CSS to load google fonts over https instead.