### PR TITLE
Add support for disqus comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you really enjoy Long Haul and want to give me credit somewhere on the intern
 - Estimated Reading Time for posts
 - Stylish Drop Cap on posts
 - A Better Type Scale for all devices
+- Comments powered by Disqus
 
 ## Setup
 

--- a/_config.yml
+++ b/_config.yml
@@ -26,3 +26,6 @@ social:
   email: brimaidesigns@gmail.com
 
 google_analytics: "UA-58263416-1"
+
+disqus:
+    shortname: my-disqus-shortname

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,0 +1,19 @@
+{%- if page.comments != false and jekyll.environment == "production" -%}
+  <div id="disqus_thread" style="margin-top:10px;"></div>
+  <script>
+    var disqus_config = function () {
+      this.page.url = '{{ page.url | absolute_url }}';
+      this.page.identifier = '{{ page.url | absolute_url }}';
+    };
+
+    (function() {
+      var d = document, s = d.createElement('script');
+
+      s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
+
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+{%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,3 +30,7 @@ layout: default
     {% endif %} 
   </div>
 </div>
+
+{%- if site.disqus.shortname -%}
+  {%- include disqus_comments.html -%}
+{%- endif -%}


### PR DESCRIPTION
I added support for disqus comments. This is pretty common with Jekyll blogs, and even [mininma](https://github.com/jekyll/minima) has support for them.

I've used it in my [personal blog](https://matheusrich.github.io/lessons-learned-on-gsoc-2019/) and it looks great!

Screenshot:
![image](https://user-images.githubusercontent.com/20938712/76690927-ce584000-6623-11ea-8f17-00d71907dff8.png)

Related issues: #74 #70 
