### PR TITLE
Add baseurl property

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       sass-listen (~> 4.0.0)
     sass-embedded (1.58.0-arm64-darwin)
       google-protobuf (~> 3.21)
+    sass-embedded (1.58.0-x64-mingw-ucrt)
+      google-protobuf (~> 3.21)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -71,6 +73,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x64-mingw-ucrt
 
 DEPENDENCIES
   http_parser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,6 @@ GEM
       sass-listen (~> 4.0.0)
     sass-embedded (1.58.0-arm64-darwin)
       google-protobuf (~> 3.21)
-    sass-embedded (1.58.0-x64-mingw-ucrt)
-      google-protobuf (~> 3.21)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -73,7 +71,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
-  x64-mingw-ucrt
 
 DEPENDENCIES
   http_parser

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,8 @@ title: Long Haul
 description: Long Form Jekyll theme built with SASS
 
 url: https://long-haul.netlify.app
-baseurl: # This is only necessary when hosting your site in a sub-directory. Project sites hosted on GitHub Pages are the common use-case of this variable.
+# Only necessary when hosting your site in a sub-directory. Project sites hosted on GitHub Pages are the common use-case of this variable.
+baseurl: # Ex: /project-page
 paginate_path: "blog/page:num/"
 permalink: blog/:title/
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Long Haul
 description: Long Form Jekyll theme built with SASS
 
 url: https://long-haul.netlify.app
-baseurl:
+baseurl: # This is only necessary when hosting your site in a sub-directory. Project sites hosted on GitHub Pages are the common use-case of this variable.
 paginate_path: "blog/page:num/"
 permalink: blog/:title/
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ title: Long Haul
 description: Long Form Jekyll theme built with SASS
 
 url: https://long-haul.netlify.app
+baseurl:
 paginate_path: "blog/page:num/"
 permalink: blog/:title/
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -34,7 +34,7 @@
 	/>
 	{%- else -%}
 	<meta
-		content="{{ '/assets/img/touring.jpg' | prepend: site.url }}"
+		content="{{ '/assets/img/touring.jpg' | relative_url }}"
 		property="og:image"
 	/>
 	{%- endif -%}
@@ -61,24 +61,24 @@
 	{%- else -%}
 	<meta
 		name="twitter:image:src"
-		content="{{ '/assets/img/touring.jpg' | prepend: site.url }}"
+		content="{{ '/assets/img/touring.jpg' | absolute_url }}"
 	/>
 	{%- endif -%}
 
 	<!-- Favicon -->
-	<link rel="icon" type="image/x-icon" href="/assets/img/favicon.ico" />
+	<link rel="icon" type="image/x-icon" href={{"/assets/img/favicon.ico" | relative_url }}/>
 
 	<!-- Come and get me RSS readers -->
 	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}"
-	href="{{ "/feed.xml" | prepend: site.url }}" />
+	href="{{ "/feed.xml" | absolute_url }}" />
 
 	<!-- Stylesheet -->
-	<link rel="stylesheet" href="/assets/css/style.css" />
+	<link rel="stylesheet" href={{"/assets/css/style.css" | relative_url }} />
 
 	<!-- Canonical URL -->
 	<link
 		rel="canonical"
-		href="{{ page.url | replace:'index.html','' | prepend: site.url }}"
+		href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}"
 	/>
 
 	{%- if site.google_analytics -%} {%- include google_analytics.html -%} {%-

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,21 +20,21 @@
 	{%- else -%}
 	<meta content="{{ site.description }}" property="og:description" />
 	{%- endif -%} {%- if page.url -%}
-	<meta content="{{ site.url }}{{ page.url }}" property="og:url" />
+	<meta content="{{ page.url | absolute_url }}" property="og:url" />
 	{%- endif -%} {%- if page.date -%}
 	<meta
 		content="{{ page.date | date_to_xmlschema }}"
 		property="article:published_time"
 	/>
-	<meta content="{{ site.url }}/about/" property="article:author" />
+	<meta content="{{ '/about/' | absolute_url }}" property="article:author" />
 	{%- endif -%} {%- if page.image -%}
 	<meta
-		content="{{ site.url }}/assets/img/{{ page.image }}"
+		content="{{ '/assets/img/' | append:page.image | absolute_url }}"
 		property="og:image"
 	/>
 	{%- else -%}
 	<meta
-		content="{{ '/assets/img/touring.jpg' | relative_url }}"
+		content="{{ '/assets/img/touring.jpg' | absolute_url }}"
 		property="og:image"
 	/>
 	{%- endif -%}
@@ -48,7 +48,7 @@
 	{%- else -%}
 	<meta name="twitter:title" content="{{ site.title }}" />
 	{%- endif -%} {%- if page.url -%}
-	<meta name="twitter:url" content="{{ site.url }}{{ page.url }}" />
+	<meta name="twitter:url" content="{{ page.url | absolute_url }}" />
 	{%- endif -%} {%- if page.description -%}
 	<meta name="twitter:description" content="{{ page.description }}" />
 	{%- else -%}
@@ -56,7 +56,7 @@
 	{%- endif -%} {%- if page.image -%}
 	<meta
 		name="twitter:image:src"
-		content="{{ site.url }}/assets/img/{{ page.image }}"
+		content="{{ '/assets/img/' | append:page.image | absolute_url }}"
 	/>
 	{%- else -%}
 	<meta
@@ -66,19 +66,19 @@
 	{%- endif -%}
 
 	<!-- Favicon -->
-	<link rel="icon" type="image/x-icon" href={{"/assets/img/favicon.ico" | relative_url }}/>
+	<link rel="icon" type="image/x-icon" href="{{/assets/img/favicon.ico | relative_url }}"/>
 
 	<!-- Come and get me RSS readers -->
 	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}"
-	href="{{ "/feed.xml" | absolute_url }}" />
+	href="{{ '/feed.xml' | absolute_url }}" />
 
 	<!-- Stylesheet -->
-	<link rel="stylesheet" href={{"/assets/css/style.css" | relative_url }} />
+	<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
 
 	<!-- Canonical URL -->
 	<link
 		rel="canonical"
-		href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}"
+		href="{{ page.url | absolute_url | replace:'index.html','' }}"
 	/>
 
 	{%- if site.google_analytics -%} {%- include google_analytics.html -%} {%-

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
- <div class="header {% if site.header == "large" %}header--large{% endif %}">
+ <div class="header {% if site.header == 'large' %}header--large{% endif %}">
      <div class="container">
-         <h1 class="logo"><a href={{ "/" | relative_url }}>{{ site.title }}</a></h1>
+         <h1 class="logo"><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
          <nav class="nav-collapse">
              <ul class="noList">
                  {%- for link in site.navigation -%}{%- assign current = nil -%}{%- if page.url contains link.url or forloop.first and page.url == '/' or page.url == 'index.html' -%}{%- assign current = 'current' -%}{%- endif -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,12 +1,12 @@
  <div class="header {% if site.header == "large" %}header--large{% endif %}">
      <div class="container">
-         <h1 class="logo"><a href="/">{{ site.title }}</a></h1>
+         <h1 class="logo"><a href={{ "/" | relative_url }}>{{ site.title }}</a></h1>
          <nav class="nav-collapse">
              <ul class="noList">
                  {%- for link in site.navigation -%}{%- assign current = nil -%}{%- if page.url contains link.url or forloop.first and page.url == '/' or page.url == 'index.html' -%}{%- assign current = 'current' -%}{%- endif -%}
                  <li class="element {%- if forloop.first -%}first{%- endif -%} {{ current }} {%- if forloop.last -%}last{%- endif -%}">
-                     <a href="{{ link.url }}">{{ link.title }}</a>
-                 </li> 
+                     <a href="{{ link.url | relative_url }}">{{ link.title }}</a>
+                 </li>
                  {%- endfor -%}
                  <li> <a href="https://github.com/brianmaierjr/long-haul" target="_blank">GitHub</a></li>
                  <li><a href="https://github.com/brianmaierjr/long-haul/archive/master.zip">Download Theme</a></li>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,6 @@
 <!-- Add jQuery and other scripts -->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="/assets/js/jquery-1.11.2.min.js"><\/script>')</script>
-<script src="/assets/js/dropcap.min.js"></script>
-<script src="/assets/js/responsive-nav.min.js"></script>
-<script src="/assets/js/scripts.js"></script>
+<script>window.jQuery || document.write('<script src={{ "/assets/js/jquery-1.11.2.min.js" | relative_url }}><\/script>')</script>
+<script src={{ '/assets/js/dropcap.min.js' | relative_url }}></script>
+<script src={{ '/assets/js/responsive-nav.min.js' | relative_url }}></script>
+<script src={{ '/assets/js/scripts.js' | relative_url }}></script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,6 @@
 <!-- Add jQuery and other scripts -->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src={{ "/assets/js/jquery-1.11.2.min.js" | relative_url }}><\/script>')</script>
-<script src={{ '/assets/js/dropcap.min.js' | relative_url }}></script>
-<script src={{ '/assets/js/responsive-nav.min.js' | relative_url }}></script>
-<script src={{ '/assets/js/scripts.js' | relative_url }}></script>
+<script src="{{ '/assets/js/dropcap.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/responsive-nav.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/scripts.js' | relative_url }}"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 <article class="post">
   {%- if page.image -%}
     <div class="featuredImage">
-        <img src="{{ '/assets/img/' | append: page.image }}" alt="" />
+        <img src="{{ '/assets/img/' | append: page.image | relative_url }}" alt="" />
       </div>
   {%- endif -%}
   <header>
@@ -16,20 +16,20 @@ layout: default
 
   <!-- POST NAVIGATION -->
   <footer class="postNav clearfix">
-    {%- if page.previous.url -%} 
-      <a class="prev{% if page.previous.image %} image{% endif %}" href="{{ page.previous.url }}"><span>&laquo;&nbsp;{{ page.previous.title }}</span>
-      {%- if page.previous.image -%} 
-        <img src="{{ '/assets/img/' |  append: page.previous.image }}" alt="">
+    {%- if page.previous.url -%}
+      <a class="prev{% if page.previous.image %} image{% endif %}" href="{{ page.previous.url | relative_url }}"><span>&laquo;&nbsp;{{ page.previous.title }}</span>
+      {%- if page.previous.image -%}
+        <img src="{{ '/assets/img/' |  append: page.previous.image | relative_url }}" alt="">
       {%- endif -%}
     </a>
-    {%- endif -%}  
-    {%- if page.next.url -%}  
-      <a class="next{% if page.next.image %} image{% endif %}" href="{{ page.next.url }}"><span>{{ page.next.title }}&nbsp;&raquo;</span>
-      {%- if page.next.image -%} 
-        <img src="{{ '/assets/img/' | append: page.next.image }}" alt="">
-      {%- endif -%} 
+    {%- endif -%}
+    {%- if page.next.url -%}
+      <a class="next{% if page.next.image %} image{% endif %}" href="{{ page.next.url | relative_url }}"><span>{{ page.next.title }}&nbsp;&raquo;</span>
+      {%- if page.next.image -%}
+        <img src="{{ '/assets/img/' | append: page.next.image | relative_url }}" alt="">
+      {%- endif -%}
       </a>
-    {%- endif -%} 
+    {%- endif -%}
   </footer>
 </article>
 

--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ title: About Long Haul
 
 <div class="post">
 	<h1 class="pageTitle">About Long Haul</h1>
-	<img src="{{ '/assets/img/touring.jpg' }}" alt="">
+	<img src="{{ '/assets/img/touring.jpg' | relative_url }}" alt="">
 	<p class="intro">Long Haul is a minimal, long form <a href="http://jekyllrb.com">Jekyll</a> Theme. It can be used as is or customized to your hearts desire.</p>
 	<p>Long Haul was created in honor of all the hard working touring bicycles that have traversed the globe time and time again. Take it for a spin.</p>
 	<h2>Features</h2>

--- a/articles.md
+++ b/articles.md
@@ -9,7 +9,7 @@ title: Your New Jekyll Site
     {%- for post in site.posts -%}
       <li>
       	<span class="date">{{ post.date | date_to_string }}</span>
-      	<h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+      	<h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
       	<p class="description">{%- if post.description -%}{{ post.description  | strip_html | strip_newlines | truncate: 120 }}{%- else -%}{{ post.content | strip_html | strip_newlines | truncate: 120 }}{%- endif -%}</p>
       </li>
     {%- endfor -%}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: Long Haul
 		<article>
 			<span class="date">{{ post.date | date: '%B %d, %Y' }}</span>
 			<h3>
-				<a class="post-link" href="{{ post.url }}">{{ post.title }}</a>
+				<a class="post-link" href="{{ post.url | relative_url }}">{{ post.title }}</a>
 			</h3>
 			<p>
 				{%- if post.description -%}{{ post.description }}{%- else -%}{{
@@ -23,12 +23,12 @@ title: Long Haul
 	<div class="pagination">
 		{%- if paginator.previous_page -%}
 		<a
-			href="{{ paginator.previous_page_path }}"
+			href="{{ paginator.previous_page_path | relative_url }}"
 			class="previous button__outline"
 			>Newer Posts</a
 		>
 		{%- endif -%} {%- if paginator.next_page -%}
-		<a href="{{ paginator.next_page_path }}" class="next button__outline"
+		<a href="{{ paginator.next_page_path | relative_url }}" class="next button__outline"
 			>Older Posts</a
 		>
 		{%- endif -%}


### PR DESCRIPTION
This addition of the base url will allow this template to be run on GitHub Pages as a project page which uses a sub directory when hosted at the default github.io/{userName}/{projectName} url.

https://mademistakes.com/mastering-jekyll/site-url-baseurl/

Not defining a base url will result in the previous functionality.

For most instances, a relative url can be used to reference within the folder structure like assets. This will prepend the baseurl to the link. For example: `/assets/img/touring.jpg` becomes `{projectName}/assets/img/touring.jpg`

For instances where the entire url is needed, prefixing the url with `{{ site.url }}` is replaced by using `absolute_url`
This will prefix the url with the site url and the base url. If the base url does not exists, only the site url is added.